### PR TITLE
update README.MD to fix wrong name on map

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ const Todos = observer(class Todos extends Component {
     return <div>
       {todos.docs.map((doc) => (
         <TodoItem
-          key={todo.id}
+          key={doc.id}
           doc={doc} />
       ))}
     </div>;


### PR DESCRIPTION
The example is mapping the docs using a variable name `doc` but was using a variable name `todo.id` insted of `doc.id` as `key`