### PR TITLE
Allow document ID to be specified when added to a collection

### DIFF
--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -475,7 +475,8 @@ class Collection<T extends ICollectionDocument = Document>
 
 	/**
 	 * Add a new document to this collection with the specified
-	 * data, assigning it a document ID automatically.
+	 * data, assigning it the given ID if specified.  Otherwise, 
+	 * a document ID will be assigned automatically.
 	 *
 	 * @example
 	 * const doc = await collection.add({
@@ -486,7 +487,7 @@ class Collection<T extends ICollectionDocument = Document>
 	 *   }
 	 * });
 	 */
-	public async add(data: any): Promise<T> {
+	public async add(data: any, id?: string): Promise<T> {
 		const ref = this.ref;
 		if (!ref) {
 			throw new Error("No valid collection reference");
@@ -498,7 +499,7 @@ class Collection<T extends ICollectionDocument = Document>
 				data: () => data,
 				exists: false,
 				get: (fieldPath: string) => data[fieldPath],
-				id: "",
+				id: id || "",
 				isEqual: () => false,
 				metadata: undefined,
 				ref: undefined

--- a/test/init.js
+++ b/test/init.js
@@ -14,7 +14,7 @@ import firebaseConfig from './firebaseConfig.json';
 let firebaseApp;
 
 beforeAll(() => {
-	jest.setTimeout(10000);
+	jest.setTimeout(30000);
 
 	// Initialize firebase
 	firebaseApp = firebase.initializeApp(firebaseConfig);

--- a/test/init.js
+++ b/test/init.js
@@ -14,7 +14,7 @@ import firebaseConfig from './firebaseConfig.json';
 let firebaseApp;
 
 beforeAll(() => {
-	jest.setTimeout(30000);
+	jest.setTimeout(10000);
 
 	// Initialize firebase
 	firebaseApp = firebase.initializeApp(firebaseConfig);


### PR DESCRIPTION
I'd like to be able to specify a custom document ID when using ```Collection.add(...)``` rather than getting an auto-generated ID.  this change should be backwards-compatible.  If no document ID is specified we should get the existing behavior of an auto-generated ID.

Let me know if you think it would be better to add a new interface for this, like ```IDocumentCreationOptions``` or something along those lines.  I don't know if it might be useful to be able to pass other optional fields in the future when adding a new document to a collection.
