### PR TITLE
Add "context" option to avoid global state 

### DIFF
--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -569,6 +569,10 @@ class Collection<T extends ICollectionDocument = Document>
 		return;
 	}
 
+	public toString(): string {
+		return this.debugName
+	}
+
 	/**
 	 * @private
 	 */

--- a/src/Document.ts
+++ b/src/Document.ts
@@ -68,12 +68,12 @@ class Document implements ICollectionDocument, IEnhancedObservableDelegate, IHas
 
 	constructor(source?: DocumentSource, options: IDocumentOptions = {}) {
 		const { schema, snapshot, snapshotOptions, mode, debug, debugName, context } = options;
+		this.debugInstanceName = debugName;
 		this.sourceInput = source;
 		this.ctx = context;
 		this.refObservable = observable.box(resolveRef(source, this));
 		this.docSchema = schema;
 		this.isVerbose = debug || false;
-		this.debugInstanceName = debugName;
 		this.snapshotObservable = enhancedObservable(snapshot, this);
 		this.snapshotOptions = snapshotOptions;
 		this.collectionRefCount = 0;
@@ -189,7 +189,9 @@ class Document implements ICollectionDocument, IEnhancedObservableDelegate, IHas
 	 * doc.path = () => 'artists/' + doc2.data.artistId;
 	 */
 	public get path(): string | (() => string | undefined) | undefined {
-		let ref = this.refObservable.get();
+		// if we call toString() during initialization, eg to throw an error referring to this
+		// document, this would throw an undefined error without the guard.
+		let ref = this.refObservable && this.refObservable.get();
 		if (!ref) {
 			return undefined;
 		}

--- a/src/Document.ts
+++ b/src/Document.ts
@@ -487,6 +487,10 @@ class Document implements ICollectionDocument, IEnhancedObservableDelegate, IHas
 		return this.readyPromise;
 	}
 
+	public toString(): string {
+		return this.debugName;
+	}
+
 	/**
 	 * @private
 	 */

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -1,4 +1,5 @@
 import { firestore } from "firebase";
+import { IContext } from "./init"
 
 /**
  * Document Source.
@@ -19,6 +20,7 @@ export interface IDocumentOptions {
 	mode?: Mode;
 	debug?: boolean;
 	debugName?: string;
+	context?: IContext;
 }
 
 /**
@@ -56,6 +58,7 @@ export interface ICollectionOptions<T> {
 	minimizeUpdates?: boolean;
 	initialLocalSnapshotDetectTime?: number;
 	initialLocalSnapshotDebounceTime?: number;
+	context?: IContext;
 }
 
 /**

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,4 +1,4 @@
-import { getFirebase } from "./init";
+import { getFirebase, IHasContext } from "./init";
 import { Mode } from "./Types";
 
 /**
@@ -9,15 +9,15 @@ import { Mode } from "./Types";
  * @param {Object} fields - JSON data that supports field-paths
  * @return {Object} Result
  */
-export function mergeUpdateData(data: object, fields: object) {
+export function mergeUpdateData(data: object, fields: object, hasContext?: IHasContext) {
 	const res = {
 		...data
 	};
+	const canonicalDelete = getFirebase(hasContext).firestore.FieldValue.delete();
 	for (const key in fields) {
 		if (fields.hasOwnProperty(key)) {
 			const val = fields[key];
-			const isDelete =
-				val === (getFirebase() as any).firestore.FieldValue.delete();
+			const isDelete = canonicalDelete.isEqual(val);
 			const paths = key.split(".");
 			let dataVal = res;
 			for (let i = 0; i < paths.length - 1; i++) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,8 @@ import {
 	getFirebase,
 	getFirebaseApp,
 	getFirestore,
-	initFirestorter
+	initFirestorter,
+	makeContext,
 } from "./init";
 import { mergeUpdateData, isTimestamp } from "./Utils";
 
@@ -18,5 +19,6 @@ export {
 	getFirebaseApp,
 	mergeUpdateData,
 	Mode,
-	isTimestamp
+	isTimestamp,
+	makeContext,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
 	getFirestore,
 	initFirestorter,
 	makeContext,
+	IContext,
 } from "./init";
 import { mergeUpdateData, isTimestamp } from "./Utils";
 
@@ -21,4 +22,5 @@ export {
 	Mode,
 	isTimestamp,
 	makeContext,
+	IContext,
 };

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,8 +1,19 @@
 import { app, firestore } from "firebase";
+import * as firebaseT from "firebase";
 
-let globalFirebase: any;
-let globalFirebaseApp: app.App;
-let globalFirestore: firestore.Firestore;
+export const ModuleName = 'firestorter';
+
+export interface IContext {
+	readonly firebase: typeof firebaseT;
+	readonly app: app.App;
+	readonly firestore: firestore.Firestore;
+}
+
+export interface IHasContext {
+	readonly context?: IContext;
+}
+
+let globalContext: IContext;
 
 /**
  * Initializes `firestorter` with the firebase-app.
@@ -29,10 +40,10 @@ let globalFirestore: firestore.Firestore;
  * ...
  */
 function initFirestorter(config: {
-	firebase: any;
+	firebase: typeof firebaseT;
 	app?: string | app.App;
 }): void {
-	if (globalFirestore) {
+	if (globalContext) {
 		throw new Error(
 			"Firestorter already initialized, did you accidentally call `initFirestorter()` again?"
 		);
@@ -44,17 +55,17 @@ function initFirestorter(config: {
 			"Missing argument `firebase` specified to `initFirestorter()`"
 		);
 	}
-	globalFirebase = config.firebase;
+	const globalFirebase = config.firebase;
 
 	// Get app instance
-	globalFirebaseApp = config.app
+	const globalFirebaseApp = config.app
 		? typeof config.app === "string"
 			? globalFirebase.app(config.app)
 			: config.app
 		: globalFirebase.app();
 
 	// Get firestore instance
-	globalFirestore = globalFirebaseApp.firestore();
+	const globalFirestore = globalFirebaseApp.firestore();
 	if (!globalFirestore) {
 		throw new Error(
 			"firebase.firestore() returned `undefined`, did you forget `import 'firebase/firestore';`"
@@ -69,33 +80,52 @@ function initFirestorter(config: {
 			"invalid `firebase` argument specified to `initFirestorter()`, `firebase.firestore.FieldValue.delete` does not exist"
 		);
 	}
+
+	globalContext = {
+		app: globalFirebaseApp,
+		firebase: globalFirebase,
+		firestore: globalFirestore,
+	}
 }
 
-function getFirebase(): any {
-	if (!globalFirebase) {
-		throw new Error(
-			"No firebase reference, did you forget to call `initFirestorter` ?"
-		);
+function getContext(obj?: IHasContext): IContext {
+	if (obj && obj.context) {
+		return obj.context
 	}
-	return globalFirebase;
+
+	if (globalContext) {
+		return globalContext
+	}
+
+	if (obj) {
+		throw new Error(`No context for ${obj} or globally. Did you forget to call \`initFirestorter\` or pass {context: ...} option?`)
+	}
+
+	throw new Error(
+		`No global Firestore context. Did you forget to call \`initFirestorter\` ?`
+	)
 }
 
-function getFirebaseApp(): app.App {
-	if (!globalFirebaseApp) {
-		throw new Error(
-			"No firebase app, did you forget to call `initFirestorter` ?"
-		);
+function contextWithProperty(key: keyof IContext, obj?: IHasContext) {
+	try {
+		const context = getContext(obj)
+		if (context[key]) { return context }
+		throw new Error(`Context does not contain ${key}`)
+	} catch(err) {
+		throw new Error(`${ModuleName}: cannot get ${key}: ${err}`)
 	}
-	return globalFirebaseApp;
 }
 
-function getFirestore(): firestore.Firestore {
-	if (!globalFirestore) {
-		throw new Error(
-			"No firestore reference, did you forget to call `initFirestorter` ?"
-		);
-	}
-	return globalFirestore;
+function getFirebase(obj?: IHasContext): typeof firebaseT {
+	return contextWithProperty('firebase', obj).firebase
+}
+
+function getFirebaseApp(obj?: IHasContext): app.App {
+	return contextWithProperty('app', obj).app
+}
+
+function getFirestore(obj?: IHasContext): firestore.Firestore {
+	return contextWithProperty('firestore', obj).firestore
 }
 
 export { initFirestorter, getFirestore, getFirebase, getFirebaseApp };


### PR DESCRIPTION
This PR adds a `context: IContext` option to the constructors of
Document and Collection. An object's context contains references
to its Firebase app and Firestore instance, which will be used
instead of the global references in `init.ts`. Collections propagate
context to their child documents.

This allows consumers to use Firestorter with multiple Firebase apps,
which is especially helpful when writing tests using the
'@firebase/testing' module.

No changes are needed to existing code: if `context` is undefined on
a Document or Collection, the global context will be used instead.

---

I haven't added tests for the new `context` option yet: I first wanted to ask for feedback on this approach. Does this seem like a useful feature, @IjzerenHein?

I'm hoping to test my Firestorter code  against the Firestore simulator following [this testing pattern](https://github.com/sgr-ksmt/firestore-emulator-rules-test/blob/master/test/)