### PR TITLE
Allow hasDocs when mode = "off" and mobx computedRequiresReaction

### DIFF
--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -209,6 +209,18 @@ class Collection<T extends ICollectionDocument = Document>
 	 * @type {boolean}
 	 */
 	public get hasDocs(): boolean {
+		if (this.mode === Mode.Off) {
+			// Avoid computed property
+			return this.docs.length > 0;
+		}
+		return this._hasDocsComputed;
+	}
+
+	/**
+	 * @private
+	 * Internal getter so we can avoid computed properties when mobx configure computedRequiresReaction and mode is Off
+	 */
+	public get _hasDocsComputed(): boolean {
 		return this.docs.length > 0;
 	}
 
@@ -1028,6 +1040,6 @@ class Collection<T extends ICollectionDocument = Document>
 	}
 }
 
-decorate(Collection, { hasDocs: computed });
+decorate(Collection, { _hasDocsComputed: computed });
 
 export default Collection;

--- a/test/Collection.hasDocs.test.ts
+++ b/test/Collection.hasDocs.test.ts
@@ -1,27 +1,25 @@
-import { autorun, Collection, Mode } from "./init";
+import { autorun, Collection } from "./init";
 
 test("false when missing ref/path", async () => {
-	const col = new Collection();
+	const col = new Collection(undefined, { mode: "off" });
 	expect(col.hasDocs).toBeFalsy();
 });
 
 test("false when collection empty", async () => {
 	expect.assertions(1);
 	const col = new Collection("artists", {
-		mode: Mode.On,
+		mode: "off",
 		query: ref => ref.where("genre", "==", "none")
 	});
-	await col.ready();
-	expect(col.hasDocs).toBeFalsy();
-	col.mode = "off";
+	await col.fetch();
+	expect(col.hasDocs).toEqual(false);
 });
 
 test("true when collection not empty", async () => {
 	expect.assertions(1);
-	const col = new Collection("artists", { mode: "on" });
-	await col.ready();
-	expect(col.hasDocs).toBeTruthy();
-	col.mode = "off";
+	const col = new Collection("artists", { mode: "off" });
+	await col.fetch();
+	expect(col.hasDocs).toEqual(true);
 });
 
 test("should not react when number of docs changes", async () => {

--- a/test/Collection.path.test.js
+++ b/test/Collection.path.test.js
@@ -51,8 +51,7 @@ test('change path to forbidden collection', async () => {
 	col.path = 'forbidden';
 	try {
 		await col.fetch();
-	}
-	catch (err) {
+	} catch (err) {
 		expect(err).toBeDefined();
 	}
 	expect(col.docs.length).toBe(0);

--- a/test/Collection.reactivePath.test.js
+++ b/test/Collection.reactivePath.test.js
@@ -41,7 +41,9 @@ test('document data', async () => {
 	expect.assertions(9);
 	const doc = new Document('settings/setting');
 	expect(doc.isActive).toBe(false);
-	const col = new Collection(() => doc.hasData ? `artists/${doc.data.topArtistId}/albums` : undefined);
+	const col = new Collection(() =>
+		doc.hasData ? `artists/${doc.data.topArtistId}/albums` : undefined
+	);
 	expect(doc.isActive).toBe(false);
 	expect(col.isActive).toBe(false);
 	const dispose = autorun(() => {

--- a/test/Document.path.test.js
+++ b/test/Document.path.test.js
@@ -51,8 +51,7 @@ test('change path to inaccessible document', async () => {
 	doc.path = 'forbidden/cantReadMe';
 	try {
 		await doc.fetch();
-	}
-	catch (err) {
+	} catch (err) {
 		expect(err).toBeDefined();
 	}
 	expect(doc.hasData).toBe(false);

--- a/test/Document.update.test.js
+++ b/test/Document.update.test.js
@@ -5,7 +5,7 @@ const ArtistSchema = struct({
 	genre: 'string',
 	memberCount: 'number?',
 	members: 'object?',
-	topAlbumId: 'string',
+	topAlbumId: 'string'
 });
 
 test('update field', async () => {
@@ -83,6 +83,10 @@ test('update field with invalid schema', async () => {
 			blaat: 10
 		});
 	} catch (e) {
-		expect(e).toEqual(new Error('Invalid value at "blaat" for Document with id "FooFighters": Expected a value of type `undefined` for `blaat` but received `10`.'));
+		expect(e).toEqual(
+			new Error(
+				'Invalid value at "blaat" for Document with id "FooFighters": Expected a value of type `undefined` for `blaat` but received `10`.'
+			)
+		);
 	}
 });

--- a/test/init.js
+++ b/test/init.js
@@ -23,7 +23,7 @@ beforeAll(() => {
 	const firestore = firebase.firestore();
 
 	// Configure mobx strict-mode
-	configure({ enforceActions: 'always' });
+	configure({ enforceActions: 'always', computedRequiresReaction: true });
 
 	// Initialize firestorter
 	initFirestorter({ firebase: firebase, app: firebaseApp });
@@ -45,9 +45,9 @@ export {
 	getFirebase,
 	Collection,
 	Document,
+	Mode,
 	isTimestamp,
 	autorun,
 	reaction,
-	observable,
-	Mode
+	observable
 };

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,0 +1,21 @@
+module.exports = function(w) {
+	return {
+		files: [
+			'src/*.ts',
+			'test/*.{ts,js}',
+			'!test/*.test.{ts,js}',
+			{ pattern: 'babel.config.js', instrument: false },
+			{ pattern: 'test/firebaseConfig.json', instrument: false }
+		],
+		tests: ['test/*.test.{ts,js}'],
+		env: {
+			type: 'node'
+		},
+		workers: {
+			// Since tests re-use the same collections
+			initial: 1,
+			regular: 1
+		},
+		testFramework: 'jest'
+	};
+};


### PR DESCRIPTION
As the `hasDocs` getter was computed it would cause a mobx error when called outside of a reaction (when `collection.mode === Mode.Off`) and mobx was configured as `computedRequiresReaction`. So this now makes a separate internal computed property `_hasDocsComputed` which is called in reactive modes, otherwise it calculates it directly. 

I'd prefer `_hasDocsComputed` was declared private in TS but that doesn't work in the `decorate` call :(

There is some other reformatting committed thanks to Prettier. 

I've also committed `wallaby.js` for running these tests with Wallaby (which I'd highly recommend for anyone doing unit testing in JS). Normally Wallaby does not need a config file but since the tests all share a single DB they can't be run in parallel so I have to disable that. Have you considered switching to the Firestore emulator? It's quite easy with that to create a separate DB for each parallel test run. Testing would be much faster. 