### PR TITLE
make IDocument generic

### DIFF
--- a/src/Types.ts
+++ b/src/Types.ts
@@ -26,8 +26,9 @@ export interface IDocumentOptions {
 /**
  * Document interface.
  */
-export interface IDocument {
+export interface IDocument<T=any> {
 	readonly id: string | undefined;
+	data: T | undefined; 
 }
 
 /**


### PR DESCRIPTION
Matching types to usage. 

Document.data is of type argument T of Document<T>.