### PR TITLE
docs: update AggregateCollection documentation

### DIFF
--- a/docs/api/AggregateCollection.md
+++ b/docs/api/AggregateCollection.md
@@ -1,8 +1,9 @@
 <a name="AggregateCollection"></a>
 
 ## AggregateCollection
-<p>Collection that aggregates the documents of one or more collections into
+<p>Collection that aggregates documents resulting from multiple queries done to a single collection into
 a single, easy accessible collection.</p>
+
 <p>AggregateCollection is driven by the <code>queries</code> function, which defines what
 queries should be executed on the Firestore cloud back-end. GeoQuery is
 for instance a more specific use-case of a aggregated-collection using a range

--- a/docs/api/AggregateCollection.md
+++ b/docs/api/AggregateCollection.md
@@ -1,7 +1,7 @@
 <a name="AggregateCollection"></a>
 
 ## AggregateCollection
-<p>Collection that aggregates documents resulting from multiple queries done to a single collection into
+<p>Collection that aggregates documents resulting from multiple queries made to a single collection into
 a single, easy accessible collection.</p>
 
 <p>AggregateCollection is driven by the <code>queries</code> function, which defines what


### PR DESCRIPTION
`AggregateCollection` doesn't actually pulls data from `multiple` collections.
It does aggregates documents resulting from `multiple queries` being made to a `single` collection.