### PR TITLE
Preserve property read side effects during tree shaking

### DIFF
--- a/tsdx.config.js
+++ b/tsdx.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  rollup: (config, options) => ({
+    ...config,
+    ...{
+      // Preserve property read side effects during tree shaking
+      treeshake: {propertyReadSideEffects: true},
+    },
+  }),
+};


### PR DESCRIPTION
Preserve property read side effects during tree shaking.

With default tsdx settings, tree shaking assumes that there will be no side effects for object reads. This currently breaks firestorter functionality when the sync mode is set to 'Auto', which is the recommended setting. Specifically, the following lines are removed from the compiled js:
- [Line 1](https://github.com/IjzerenHein/firestorter/blob/b00c7a28161c0277c0a40d5d4b19a4b927758382/src/Collection.ts#L483)
- [Line 2](https://github.com/IjzerenHein/firestorter/blob/b00c7a28161c0277c0a40d5d4b19a4b927758382/src/Collection.ts#L497)
- [Line 3](https://github.com/IjzerenHein/firestorter/blob/b00c7a28161c0277c0a40d5d4b19a4b927758382/src/Collection.ts#L980)

You can inspect `firestorter.cjs.development.js` to see it clearly.

This implies that observing (via mobx) these getters (i.e. `isLoaded`) will not have the intended effect of tracking that observable reference, and fetching data from the Firestore collection.